### PR TITLE
Added support for configuring a configuration prefix for all rabbitmq conf properties

### DIFF
--- a/src/main/java/com/bq/oss/lib/rabbitmq/ioc/AbstractRabbitMQConfiguration.java
+++ b/src/main/java/com/bq/oss/lib/rabbitmq/ioc/AbstractRabbitMQConfiguration.java
@@ -15,6 +15,8 @@ import org.springframework.core.env.Environment;
 
 import com.bq.oss.lib.rabbitmq.config.RabbitMQConfigurer;
 
+import java.util.Optional;
+
 @Configuration
 public abstract class AbstractRabbitMQConfiguration {
 
@@ -68,6 +70,10 @@ public abstract class AbstractRabbitMQConfiguration {
 
 	protected abstract Environment getEnvironment();
 
+	protected Optional<String> configPrefix() {
+		return Optional.empty();
+	}
+
 	/**
 	 * Override by subclasses to define the {@link MessageConverter} of the {@link AmqpTemplate}
 	 */
@@ -76,30 +82,34 @@ public abstract class AbstractRabbitMQConfiguration {
 	}
 
 	protected String getRabbitHost() {
-		return getEnvironment().getProperty("rabbitmq.host");
+		return getEnvironment().getProperty(configKey("rabbitmq.host"));
 	}
 
 	protected int getRabbitPort() {
-		return getEnvironment().getProperty("rabbitmq.port", int.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.port"), int.class);
 	}
 
 	protected String getRabbitUsername() {
-		return getEnvironment().getProperty("rabbitmq.username", String.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.username"), String.class);
 	}
 
 	protected String getRabbitPassword() {
-		return getEnvironment().getProperty("rabbitmq.password", String.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.password"), String.class);
 	}
 
 	protected Integer getRequestedHeartbeat() {
-		return getEnvironment().getProperty("rabbitmq.requestedHeartbeat", Integer.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.requestedHeartbeat"), Integer.class);
 	}
 
 	protected Integer getConnectionTimeout() {
-		return getEnvironment().getProperty("rabbitmq.connectionTimeout", Integer.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.connectionTimeout"), Integer.class);
 	}
 
 	protected String getVirtualHost() {
-		return getEnvironment().getProperty("rabbitmq.virtualHost", String.class);
+		return getEnvironment().getProperty(configKey("rabbitmq.virtualHost"), String.class);
+	}
+
+	private String configKey(String keyName){
+		return configPrefix().map(prefix -> prefix+".").orElse("").concat(keyName);
 	}
 }

--- a/src/test/java/com/bq/oss/lib/rabbitmq/ioc/AbstractRabbitMQConfigurationTest.java
+++ b/src/test/java/com/bq/oss/lib/rabbitmq/ioc/AbstractRabbitMQConfigurationTest.java
@@ -1,0 +1,54 @@
+package com.bq.oss.lib.rabbitmq.ioc;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Alexander De Leon <me@alexdeleon.name>
+ */
+public class AbstractRabbitMQConfigurationTest {
+
+
+    @Test
+    public void testConfigPrefix(){
+        Environment envMock = mock(Environment.class);
+        when(envMock.getProperty("test.rabbitmq.host")).thenReturn("TEST_HOST");
+
+        AbstractRabbitMQConfiguration conf = new AbstractRabbitMQConfiguration() {
+            @Override
+            protected Environment getEnvironment() {
+                return envMock;
+            }
+
+            @Override
+            protected Optional<String> configPrefix() {
+                return Optional.of("test");
+            }
+        };
+
+        Assert.assertEquals("TEST_HOST", conf.getRabbitHost());
+
+    }
+
+    @Test
+    public void testEmptyConfigPrefix(){
+        Environment envMock = mock(Environment.class);
+        when(envMock.getProperty("rabbitmq.host")).thenReturn("TEST_HOST");
+
+        AbstractRabbitMQConfiguration conf = new AbstractRabbitMQConfiguration() {
+            @Override
+            protected Environment getEnvironment() {
+                return envMock;
+            }
+        };
+
+        Assert.assertEquals("TEST_HOST", conf.getRabbitHost());
+
+    }
+}


### PR DESCRIPTION
When dockerizing corbel I found that the configuration property rabbitmq.port collapses with the environment variable that docker creates when there is a container `rabbitmq` linked. To avoid this we can add a configuration prefix so that the conf property `rabbitmq.port` becomes `eventbus.rabbitmq.port`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bq/lib-rabbitmq/1)
<!-- Reviewable:end -->
